### PR TITLE
Add check_type option to collect_and_parse_symbols

### DIFF
--- a/src/go_inspector/plugin.py
+++ b/src/go_inspector/plugin.py
@@ -104,13 +104,15 @@ def is_executable_binary(location):
     return True
 
 
-def collect_and_parse_symbols(location, **kwargs):
+
+def collect_and_parse_symbols(location, check_type=True, **kwargs):
     """
     Run GoReSym and return a mapping of symbols of interest for the Go binary file
     at ``location``.
+    If ``check_type`` is True, the file is checked.
     """
-    if not is_executable_binary(location):
-        print("Not an executable binary")
+    if check_type and not is_executable_binary(location):
+        # print("Not an executable binary")
         return
 
     goresym_args = ["-p", location]


### PR DESCRIPTION
Add check_type option to collect_and_parse_symbols to skip checking the filetype when not needed.

Also comment print() statement